### PR TITLE
Columns style to WooCommerce products list

### DIFF
--- a/src/_products-columns.scss
+++ b/src/_products-columns.scss
@@ -1,0 +1,20 @@
+@use "sass:math";
+@import "./flexbox";
+
+.woocommerce {
+	ul.products {
+		@for $i from 1 through 6 {
+			&.columns-#{$i} {
+				@include box(wrap);
+				--products-columns-gap: 30px;
+				gap: var(--products-columns-gap);
+
+				li.product {
+
+					$subtrahend: calc(var(--products-columns-gap) * #{math.div(($i - 1), $i)});
+					width: calc(#{math.div(100%, $i)} - #{$subtrahend});
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
I have added the `products columns` style to reuse in the blocks like Shop by categories and Products.