### PR TITLE
Reused CSS Keyframes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-style-utils",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-style-utils",
-			"version": "1.3.0",
+			"version": "1.4.0",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "4.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-style-utils",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "A collection of SCSS utilities and variables.",
 	"keywords": [
 		"gutenberg",

--- a/src/keyframes/_fade-in.scss
+++ b/src/keyframes/_fade-in.scss
@@ -1,0 +1,11 @@
+$prefix: sixa;
+
+@keyframes #{$prefix}FadeIn {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}

--- a/src/keyframes/_fade-out-half.scss
+++ b/src/keyframes/_fade-out-half.scss
@@ -1,0 +1,11 @@
+$prefix: sixa;
+
+@keyframes #{$prefix}FadeOutHalf {
+	0% {
+		opacity: 1;
+	}
+
+	100% {
+		opacity: 0.5;
+	}
+}

--- a/src/keyframes/_fade-out.scss
+++ b/src/keyframes/_fade-out.scss
@@ -1,0 +1,11 @@
+$prefix: sixa;
+
+@keyframes #{$prefix}FadeOut {
+	0% {
+		opacity: 0;
+	}
+
+	100% {
+		opacity: 1;
+	}
+}

--- a/src/keyframes/_index.scss
+++ b/src/keyframes/_index.scss
@@ -1,0 +1,4 @@
+@import "./fade-in";
+@import "./fade-out-half";
+@import "./fade-out";
+@import "./spin";

--- a/src/keyframes/_spin.scss
+++ b/src/keyframes/_spin.scss
@@ -1,0 +1,11 @@
+$prefix: sixa;
+
+@keyframes #{$prefix}Spin {
+	0% {
+		transform: translateZ(0) rotate(0deg);
+	}
+
+	100% {
+		transform: translateZ(0) rotate(360deg);
+	}
+}


### PR DESCRIPTION
This PR proposes the addition of the most (re)used CSS animation keyframes to be included as part of this package. The keyframes can either be imported in bulk or individually by directly addressing the corresponding file name.